### PR TITLE
Pull Request Version of Changes for Matt

### DIFF
--- a/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading.xcodeproj/project.pbxproj
+++ b/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading.xcodeproj/project.pbxproj
@@ -706,6 +706,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -761,6 +763,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading/ImageCache.swift
+++ b/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading/ImageCache.swift
@@ -4,55 +4,57 @@ See the LICENSE.txt file for this sample’s licensing information.
 Abstract:
 The Image cache.
 */
-import UIKit
 import Foundation
-public class ImageCache {
-    
-    public static let publicCache = ImageCache()
-    var placeholderImage = UIImage(systemName: "rectangle")!
-    private let cachedImages = NSCache<NSURL, UIImage>()
-    private var loadingResponses = [NSURL: [(Item, UIImage?) -> Swift.Void]]()
-    
-    public final func image(url: NSURL) -> UIImage? {
-        return cachedImages.object(forKey: url)
+import UIKit
+
+public actor ImageCache {
+
+    enum LoadingError: Error {
+        case badImageData
     }
+
+    static let publicCache = ImageCache()
+
+    let placeholderImage = UIImage(systemName: "rectangle")!
+    let brokenImage = UIImage(systemName: "rectangle.slash")!
+
+    /// This isn't exactly Sendable so we'll see!
+    private let cachedImages = NSCache<NSURL, UIImage>()
+    /// This replaces the dictionary that had the closure returning the item and UIImage when complete.
+    /// Instead, we'll hold the tasks that we can cancel if we need to.
+    private var loadingResponses = [URL: Task<(UIImage), any Error>]()
+
+    public final func image(url: URL) -> UIImage? {
+        return cachedImages.object(forKey: url as NSURL)
+    }
+
     /// - Tag: cache
     // Returns the cached image if available, otherwise asynchronously loads and caches it.
-    final func load(url: NSURL, item: Item, completion: @escaping (Item, UIImage?) -> Swift.Void) {
+    final func load(url: URL) async throws -> UIImage {
         // Check for a cached image.
         if let cachedImage = image(url: url) {
-            DispatchQueue.main.async {
-                completion(item, cachedImage)
-            }
-            return
+            return cachedImage
         }
-        // In case there are more than one requestor for the image, we append their completion block.
-        if loadingResponses[url] != nil {
-            loadingResponses[url]?.append(completion)
-            return
-        } else {
-            loadingResponses[url] = [completion]
+        // In case there are more than one requestor for the image, we wait for the previous request and
+        // return the image (or throw)
+        if let previousTask = loadingResponses[url] {
+            return try await previousTask.value
         }
+
         // Go fetch the image.
-        ImageURLProtocol.urlSession().dataTask(with: url as URL) { [weak self] (data, response, error) in
-            // Check for the error, then data and try to create the image.
-            guard let self, let responseData = data, let image = UIImage(data: responseData),
-                let blocks = self.loadingResponses[url], error == nil else {
-                DispatchQueue.main.async {
-                    completion(item, nil)
-                }
-                return
+        let currentTask = Task {
+            // TODO: JVO update ImageURLProtocol with modern version.
+            let (data, _) = try await ImageURLProtocol.urlSession().data(from: url)
+            // Try to create the image. If not, throw bad image data error.
+            guard let image = UIImage(data: data) else {
+                throw LoadingError.badImageData
             }
             // Cache the image.
-            self.cachedImages.setObject(image, forKey: url, cost: responseData.count)
-            // Iterate over each requestor for the image and pass it back.
-            for block in blocks {
-                DispatchQueue.main.async {
-                    block(item, image)
-                }
-                return
-            }
-        }.resume()
+            cachedImages.setObject(image, forKey: url as NSURL, cost: data.count)
+            return image
+        }
+        // We will save the Task in case another request comes for the same URL.
+        loadingResponses[url] = currentTask
+        return try await currentTask.value
     }
-        
 }

--- a/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading/Item.swift
+++ b/AsynchronouslyLoadingImagesIntoTableAndCollectionViews/Async Image Loading/Item.swift
@@ -10,22 +10,25 @@ enum Section {
     case main
 }
 
-class Item: Hashable {
-    
+@MainActor
+class Item: Identifiable {
+
     var image: UIImage!
+    var isImageLoaded: Bool = false
     let url: URL!
-    let identifier = UUID()
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier)
-    }
-    static func == (lhs: Item, rhs: Item) -> Bool {
-        return lhs.identifier == rhs.identifier
-    }
-    
+    let id = UUID()
+
     init(image: UIImage, url: URL) {
         self.image = image
         self.url = url
     }
+}
 
+extension Item: Hashable, Equatable {
+    nonisolated func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    nonisolated static func == (lhs: Item, rhs: Item) -> Bool {
+        return lhs.id == rhs.id
+    }
 }


### PR DESCRIPTION
This is my initial take on how to convert the code that Apple wrote to something more modern. 

If you want my breakdown of what the code was doing before, [here is my blog entry about it](https://jacobvanorder.github.io/structured-concurrency-conversion-part-1/). 

As I was writing today:

> Before we start, I want to reference back to Swift's release in 2014. There was a tendency for developers with years of Objective-C experience to write Swift code using the same patterns, which often resulted in the fuzzy, subjective judgment that the code wasn't "Swifty" enough. Something similar is happening again with Structured Concurrency. After years of writing code that explicitly manages threading and handles locks, we now have a handy tool that allows us to catch potential data races before compilation. However, as we learn this new approach, our code might initially mimic older patterns to some degree. The reason I mention this is if you squint at the old code in the exercise, you should be able to see how it translates to something more modern. The underlying patterns and structure are somewhat present, which might help you bridge from the old way of doing things to the new, even if it doesn't fully embrace all the new paradigm has to offer.

This is my way of saying that there are probably better ways to write this code that a person who has a much deeper understanding of Structured Concurrency would take. I am trying to take an evolutionary approach to this but with that being said, feel free to comment to your heart's content. I plan on doing a Swift 6.2 update later this summer so please keep that in mind.

I deeply appreciate your offer to assist! Thank you!